### PR TITLE
In model constraints, all HTML entities should be decoded

### DIFF
--- a/lib/lutaml/xmi/parsers/xml.rb
+++ b/lib/lutaml/xmi/parsers/xml.rb
@@ -1,4 +1,5 @@
 require "nokogiri"
+require "htmlentities"
 require "lutaml/uml/has_attributes"
 require "lutaml/uml/document"
 
@@ -167,7 +168,7 @@ module Lutaml
             {
               xmi_id: constraint["xmi:id"],
               body: constraint["name"],
-              definition: constraint["description"]
+              definition: HTMLEntities.new.decode(constraint["description"])
             }
           end
         end

--- a/lutaml-xmi.gemspec
+++ b/lutaml-xmi.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "thor", "~> 1.0"
   spec.add_runtime_dependency "lutaml-uml"
   spec.add_runtime_dependency "nokogiri", "~> 1.10"
+  spec.add_runtime_dependency "htmlentities"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug"

--- a/spec/lutaml/parsers/xmi_spec.rb
+++ b/spec/lutaml/parsers/xmi_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe Lutaml::XMI::Parsers::XML do
           .to(eq(["Temporal and Zonal Geometry", "Temporal and Zonal RS using Identifiers"]))
       end
 
-      it "correctly parses package` classes" do
+      it "correctly parses package classes" do
         expect(first_nested_package.classes.map(&:name)).to(eq(expected_class_names))
         expect(first_nested_package.classes.map(&:xmi_id)).to(eq(expected_class_xmi_ids))
       end


### PR DESCRIPTION
In model constraints, all HTML entities should be decoded, fixes #12
